### PR TITLE
fix: rename tree-sitter-hypr to tree-sitter-hyprlang

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Awesome list for Hyprland, that includes useful tools and libraries that either 
 ## Config parsers
 
 - [Hyprparse](https://github.com/hyprland-community/hyprparse) ![rust][rs] (Hypr config file parser, with support for the web)
-- [tree-sitter-hypr](https://github.com/luckasRanarison/tree-sitter-hypr) ![c][c] (tree-sitter grammar for Hypr config files, made to be used with neovim)
+- [tree-sitter-hyprlang](https://github.com/luckasRanarison/tree-sitter-hyprlang) ![c][c] (tree-sitter grammar for Hyprland config files, made to be used with neovim)
 
 ## Plugins
 


### PR DESCRIPTION
Hyprland configuration files are now know as [hyprlang](https://github.com/hyprwm/hyprlang) so I renamed to repo.

Also like it finally got an official name, I'll try to make a PR to nvim-tressitter and I hope it'll get added soon.