### PR TITLE
Add wscreensaver-bridge (rust)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Awesome list for Hyprland, that includes useful tools and libraries that either 
 #### Idle Daemons
 
 - [swayidle](https://github.com/swaywm/swayidle) ![c][c] (Idle daemon used by default in sway, also only one I could find for wlroots)
+- [wscreensaver-bridge](https://github.com/kelvie/wscreensaver-bridge) ![rust][rs] (Wayland native bridge for apps that use org.freedesktop.ScreenSaver to inhibit idleness)
 
 #### Lockers
 


### PR DESCRIPTION
Not sure if this belongs here, but in case anyone else runs into this. Some apps (in my case, Stremio) uses the org.freedesktop.ScreenSaver dbus library to inhibit idle, and it needs to be translated to Wayland's idle-inhibit somehow to not have swayidle trigger.