### PR TITLE
Updated README.md [Removed gtklock as a locker entry since it is no longer functional]

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,6 @@ These technically aren't hyprland plugins, but extend hyprland functionality usi
 
 #### Lockers
 
-- [gtklock](https://github.com/jovanlanik/gtklock) ![c][c] (Fork of gtkgreet, but for locking, also more configurable, and has a its module system)
 - [swaylock](https://github.com/swaywm/swaylock) ![c][c] (Sway's default locker, very configurable, and popular)
 - [swaylock-effects](https://github.com/mortie/swaylock-effects) ![c][c] (Fork of swaylock, but with effects ^)
 - [waylock](https://codeberg.org/ifreund/waylock) ![zig][z] (A small screenlocker for Wayland compositors)


### PR DESCRIPTION
Removed gtklock as a locker entry , on the newer version of hyprland gtklock doesn't work due to the absence of wlr-input-inhibitor and the workaround isn't much safe , so not recommended.