### PR TITLE
Add wleave

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ These technically aren't hyprland plugins, but extend hyprland functionality usi
 - [Wlogout](https://github.com/ArtsyMacaw/wlogout) ![c][c] (Logout menu)
 - [wayprompt](https://git.sr.ht/~leon_plickat/wayprompt) ![zig][z] (pinentry prompter)
 - [nwg-bar](https://github.com/nwg-piotr/nwg-bar) ![go][go] (GTK3-based logout bar)
+- [wleave](https://github.com/AMNatty/wleave) ![rust][rs] (A Wayland-native logout script written in Gtk3)
 
 #### Idle Daemons
 


### PR DESCRIPTION
[wleave](https://github.com/AMNatty/wleave) is a wayland-native logout script written in Gtk3. It's basically a wlogout rewrite in rust.