### PR TITLE
remove hyprload

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Awesome list for Hyprland, that includes useful tools and libraries that either 
 
 ## Plugins
 
-- [hyprload](https://github.com/Duckonaut/hyprload) ![c++][cpp] (Hyprland plugin manager that adds support for reloading plugins)
 - [split-monitor-workspaces](https://github.com/Duckonaut/split-monitor-workspaces) ![c++][cpp] (A small Hyprland plugin to provide awesome-like workspace behavior)
 - [hyprgrass](https://github.com/horriblename/hyprgrass) ![c++][cpp] (Hyprland plugin for touch gestures)
 - [hyprNStack](https://github.com/zakk4223/hyprNStack) ![c++][cpp] (Hyprland plugin for N-stack tiling layout)


### PR DESCRIPTION
If you visit the project, you see that it is now deprecated in favor of the built-in "hyprpm" utility. The hyprload author even writes "even I have switched over to hyprpm".