### PR TITLE
add hyprswitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ These technically aren't hyprland plugins, but extend hyprland functionality usi
 - [hyprnome](https://github.com/donovanglover/hyprnome) ![rust][rs] (GNOME-like workspace switching in Hyprland)
 - [Hyprfreeze](https://github.com/Zerodya/hyprfreeze) ![shell][sh] (Utility to suspend a game process and other programs)
 - [hyprkool](https://github.com/thrombe/hyprkool) ![rust][rs] (plugin that adds kde activities and grid layouts. also allows to switch workspaces when cursor touches edges)
+- [hyprswitch](https://github.com/H3rmt/hyprswitch) ![rust][rs] (A CLI/GUI that allows switching between windows in Hyprland)
 
 ### Screenshotting
 


### PR DESCRIPTION
fixes: #69 
[Hyprswitch](https://github.com/H3rmt/hyprswitch) is a CLI/GUI that allows switching between windows in Hyprland.