### PR TITLE
add hyprnotify

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ These technically aren't hyprland plugins, but extend hyprland functionality usi
 - [dunst](https://dunst-project.org/) ![c][c] (Very customizable notification daemon)
 - [SwayNotificationCenter](https://github.com/ErikReider/SwayNotificationCenter) ![vala][va] (GNOME like notification daemon, with GUI and all)
 - [fnott](https://codeberg.org/dnkl/fnott) ![c][c] (Featureful and configurable notification daemon)
+- [hyprnotify](https://github.com/codelif/hyprnotify) ![go][go] (Notification daemon with 'hyprctl notify' as backend)
 
 #### OSD
 


### PR DESCRIPTION
Can I add [hyprnotify](https://github.com/codelif/hyprnotify)?

It is a notification daemon using 'hyprctl notify' as the backend. 
It is compliant with [Freedesktop.org Notification Spec](https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html) so other applications can send notifications through it with abstractions like `notify-send` or glib.
