### PR TITLE
Add hyprcursor and corrected capitialized cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ These technically aren't hyprland plugins, but extend hyprland functionality usi
 - [hyprpicker](https://github.com/hyprwm/hyprpicker)  ![c++][cpp] (colorpicker)
 - [hyprlock](https://github.com/hyprwm/hyprlock) ![C++][cpp] (lock screen)
 - [hypridle](https://github.com/hyprwm/hypridle) ![C++][cpp] (idle daemon)
-- [hyprcursor](https://github.com/hyprwm/hyprcursor) ![C++][cpp] (cursor format, library and utilities) **(XCursor replacement)**
+- [hyprcursor](https://github.com/hyprwm/hyprcursor) ![C++][cpp] (Utility for creating cursors for hyprland)
 
 ### Status Bar/Shell
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ These technically aren't hyprland plugins, but extend hyprland functionality usi
 - [hyprpicker](https://github.com/hyprwm/hyprpicker)  ![c++][cpp] (colorpicker)
 - [hyprlock](https://github.com/hyprwm/hyprlock) ![C++][cpp] (lock screen)
 - [hypridle](https://github.com/hyprwm/hypridle) ![C++][cpp] (idle daemon)
-- [hyprcursor](https://github.com/hyprwm/hyprcursor) ![C++][cpp] (cursor utility)
+- [hyprcursor](https://github.com/hyprwm/hyprcursor) ![C++][cpp] (cursor format, library and utilities) **(XCursor replacement)**
 
 ### Status Bar/Shell
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ These technically aren't hyprland plugins, but extend hyprland functionality usi
 - [Hyprpicker](https://github.com/hyprwm/hyprpicker)  ![c++][cpp] (colorpicker)
 - [hyprlock](https://github.com/hyprwm/hyprlock) ![C++][cpp] (lock screen)
 - [hypridle](https://github.com/hyprwm/hypridle) ![C++][cpp] (idle daemon)
+- [hyprcursor](https://github.com/hyprwm/hyprcursor) ![C++][cpp] (cursor utility)
 
 ### Status Bar/Shell
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ These technically aren't hyprland plugins, but extend hyprland functionality usi
 
 ### Official tools
 
-- [Hyprpaper](https://github.com/hyprwm/hyprpaper) ![c++][cpp] (wallpaper daemon)
-- [Hyprpicker](https://github.com/hyprwm/hyprpicker)  ![c++][cpp] (colorpicker)
+- [hyprpaper](https://github.com/hyprwm/hyprpaper) ![c++][cpp] (wallpaper daemon)
+- [hyprpicker](https://github.com/hyprwm/hyprpicker)  ![c++][cpp] (colorpicker)
 - [hyprlock](https://github.com/hyprwm/hyprlock) ![C++][cpp] (lock screen)
 - [hypridle](https://github.com/hyprwm/hypridle) ![C++][cpp] (idle daemon)
 - [hyprcursor](https://github.com/hyprwm/hyprcursor) ![C++][cpp] (cursor utility)


### PR DESCRIPTION
I've added hyprcursor in the Tools/Official Tools section.

Also, hyprpaper and hyprpicker don't start with a capitalized "h" on the hyprwm repo.
So I changed it in the Tools/Official Tools section to reflect the original repo.