### PR TITLE
Add the Ignis widget framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ These technically aren't hyprland plugins, but extend hyprland functionality usi
 - [HyprPanel](https://github.com/Jas-SinghFSU/HyprPanel) ![typescript][ts] (A Bar/Panel for Hyprland with extensive customizability and context menus.)
 - [hyprpanel](https://github.com/pdf/hyprpanel) ![go][go] (An opinionated GTK4 panel/shell)
 - [ashell](https://github.com/MalpenZibo/ashell) ![rust][rs] (A ready to go Wayland status bar for Hyprland)
+- [ignis](https://github.com/linkfrg/ignis) ![python][py] (GTK4-based widget framework for bars and other widgets)
 
 ### Notifications
 


### PR DESCRIPTION
Adding the Ignis widget framework. Similar to eww and AGS, but based on GTK4, written and configured in python.

https://github.com/linkfrg/ignis