### PR TITLE
update: `rofi-wayland` has been upstreamed

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ These technically aren't hyprland plugins, but extend hyprland functionality usi
 
 ### Runners, Menus, and Application Launchers
 
-- [rofi-wayland](https://github.com/lbonn/rofi) ![c][c] (Rofi fork with support for wlroots)
+- [rofi](https://github.com/davatorium/rofi) ![c][c] (A window switcher, application launcher and dmenu replacement)
 - [tofi](https://github.com/philj56/tofi) ![c][c] (Very tiny rofi inspired menu)
 - [bemenu](https://github.com/Cloudef/bemenu) ![c][c] (Looks like dmenu, but crossplatform)
 - [wofi](https://hg.sr.ht/~scoopta/wofi) ![c][c] (Simple menu made in gtk)


### PR DESCRIPTION
See https://github.com/lbonn/rofi/commit/d4b16e6f2fb714064d9f17287be31ea1a63134e5