### PR TITLE
Add HyprDynamicMonitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ These technically aren't hyprland plugins, but extend hyprland functionality usi
 - [wlr-rander](https://sr.ht/~emersion/wlr-randr/) ![c][c] (An xrandr clone for wlroots compositors)
 - [kanshi](https://git.sr.ht/~emersion/kanshi) ![c][c] (Dynamic display configuration)
 - [shikane](https://gitlab.com/w0lff/shikane) ![rust][rs] (Deterministic dynamic output configuration tool)
+- [HyprDynamicMonitors](https://github.com/fiffeek/hyprdynamicmonitors) ![go][go] (Power-state-aware dynamic display configuration tool with a TUI)
 - [Wayout](https://git.sr.ht/~shinyzenith/wayout) ![rust][rs] (For turning off display, useful for idle) **(can be replicated using hyprctl)**
 - [monitor-attached](https://github.com/coffebar/hyprland-monitor-attached) ![rust][rs] (Run the user's script when you connect or disconnect monitors)
 - [wl-mirror](https://github.com/Ferdi265/wl-mirror) ![c][c] (A simple Wayland output mirror client)


### PR DESCRIPTION
An event-driven service that automatically manages Hyprland monitor configurations based on connected displays and power state. Alternative to `shikane` and `kanshi`.

https://github.com/fiffeek/hyprdynamicmonitors