### PR TITLE
Add: nwg-displays

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ These technically aren't hyprland plugins, but extend hyprland functionality usi
 > **NOTICE:** Wluma needs to be updated to support newer Hyprland versions, as it currently relies on the unstable DMA-buf protocol.
 - [hyprsunset](https://github.com/hyprwm/hyprsunset) ![C++][cpp] (Hyprland utility for color temperature filter)
 - [waycorner](https://github.com/AndreasBackx/waycorner) ![rust][rs] (Hot corners for Wayland)
+- [nwg-displays](https://github.com/nwg-piotr/nwg-displays) ![python][py] (Provides an intuitive GUI to manage multiple monitors)
 
 ### Workspace
 


### PR DESCRIPTION
*nwg-displays* provides an intuitive GUI to manage multiple monitors. Works flawlessly with Hyprland.