### PR TITLE
Add: peck (A screencapture tool that supports both screenshots and screen recordings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ These technically aren't hyprland plugins, but extend hyprland functionality usi
 - [Hyprshot](https://github.com/Gustash/Hyprshot) ![shell][sh] (Another grimshot-like tool to make things easier)
 - [satty](https://github.com/gabm/satty) ![rust][rs] (A screenshot annotation tool inspired by Swappy and Flameshot)
 - [swappy](https://github.com/jtheoof/swappy) ![c][c] (A Wayland native snapshot editing tool, inspired by Snappy on macOS)
+- [peck](https://github.com/codevogel/peck) ![shell][sh] (A screencapture tool that supports both screenshots and screen recordings)
 
 #### Raw Tools
 


### PR DESCRIPTION
Adds https://github.com/codevogel/peck

`peck` is a wrapper bash script for `grim` and `wf-recorder`, providing a unified user-friendly interface to capture both screenshots and screen recordings.