### PR TITLE
Add hyprKCS to Input tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ These technically aren't hyprland plugins, but extend hyprland functionality usi
 - [hyprland-per-window-layout](https://github.com/coffebar/hyprland-per-window-layout) ![rust][rs] (Per window keyboard layout, zero-configuration, just works out of the box)
 - [hyprland-per-window-layout](https://github.com/MahouShoujoMivutilde/hyprland-per-window-layout) ![shell][sh] (Script to maintain per window keyboard layout) (language)
 - [Keymapper](https://github.com/houmain/keymapper) ![c++][cpp] (A cross-platform context-aware key remapper)
+- [hyprKCS](https://github.com/kosa12/hyprKCS) ![rust][rs] (Hyprland keybind manager with a GUI)
 
 #### On-screen Keyboards
 


### PR DESCRIPTION
I'd like to add [hyprKCS](https://github.com/kosa12/hyprKCS) the **Input** section.

**What is it?** 
hyprKCS is a native GTK4/LibadwaitaGUI tool written in Rust for managing Hyprland keybinds.