### PR TITLE
Add Monique

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ These technically aren't hyprland plugins, but extend hyprland functionality usi
 > **NOTICE:** Wluma needs to be updated to support newer Hyprland versions, as it currently relies on the unstable DMA-buf protocol.
 - [hyprsunset](https://github.com/hyprwm/hyprsunset) ![C++][cpp] (Hyprland utility for color temperature filter)
 - [waycorner](https://github.com/AndreasBackx/waycorner) ![rust][rs] (Hot corners for Wayland)
+- [Monique](https://github.com/ToRvaLDz/monique) ![python][py] (Graphical monitor configurator for Hyprland and Sway with drag-and-drop layout, profiles, and hotplug daemon)
 - [nwg-displays](https://github.com/nwg-piotr/nwg-displays) ![python][py] (Provides an intuitive GUI to manage multiple monitors)
 
 ### Workspace


### PR DESCRIPTION
Add [Monique](https://github.com/ToRvaLDz/monique) to the Display section.

Monique (MONitor Integrated QUick Editor) is a graphical monitor configurator for Hyprland and Sway featuring:

- Drag-and-drop monitor layout
- Profile system with save/load/switch
- Hotplug daemon (`moniqued`) for automatic configuration
- SDDM integration
- Workspace rules
- Confirm-or-revert safety mechanism

Built with Python, GTK4 and Libadwaita. Available on [AUR](https://aur.archlinux.org/packages/monique) and [PyPI](https://pypi.org/project/monique/).