### PR TITLE
Add wayper to Wallpaper section

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ These technically aren't hyprland plugins, but extend hyprland functionality usi
 - [swaybg](https://github.com/swaywm/swaybg) ![c][c] (Very simple wallpaper daemon used by default on sway)
 - [waypaper](https://github.com/anufrievroman/waypaper) ![python][py] (GUI wallpaper setter)
 - [waypaper engine](https://github.com/0bCdian/Waypaper-Engine) ![typescript][ts] (GUI wallpaper setter with playlist capabilities)
+- [wayper](https://github.com/yuukidach/wayper) ![python][py] (Wallpaper manager with Wallhaven integration, auto orientation matching, and MCP server)
 - [wpaperd](https://github.com/danyspin97/wpaperd) ![rust][rs] (Minimal wallpaper daemon for Wayland)
 - ~~[hyprwall](https://github.com/nnyyxxxx/hyprwall)~~ ![rust][rs](GUI for setting wallpapers with hyprpaper, swww, swaybg, wallutils, and feh)
 > Deleted, fork of hyprwall available at <https://github.com/MarkusVolk/hyprwall>


### PR DESCRIPTION
Add [wayper](https://github.com/yuukidach/wayper) — a Python wallpaper manager with Wallhaven integration, AI-native control, and GTK4 browser.

### Features

- **Wallhaven integration** — auto download, validate, resize to monitor resolution
- **Auto orientation matching** — portrait monitors get portrait wallpapers, landscape gets landscape
- **SFW/NSFW mode toggle** — one key to switch, persistent across sessions
- **Favorites & blacklist** — like/dislike with undo
- **GTK4 browser** — thumbnail grid with preview, keyboard shortcuts, category tabs
- **MCP server** — AI assistants (Claude Code, etc.) can control wallpapers natively
- **Daemon** — background rotation + auto-download with configurable intervals
- **JSON output** — `--json` flag on every command for scripting

Available on [AUR](https://aur.archlinux.org/packages/wayper).

### How is this different from waypaper?

| | wayper | waypaper |
|---|---|---|
| **Wallpaper source** | Auto-downloads from Wallhaven API | Local files only |
| **Daemon** | Background rotation + download loop | No daemon (manual restore) |
| **GUI** | GTK4 browser with preview + actions | GTK3 file browser |
| **Orientation** | Auto-matches portrait/landscape monitors | Manual selection |
| **AI control** | Built-in MCP server | None |
| **Mode toggle** | SFW/NSFW with separate pools | N/A |
| **Backend** | swww | swaybg, swww, hyprpaper, feh, etc. |