### PR TITLE
Add aifuel: AI usage monitor for waybar

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ These technically aren't hyprland plugins, but extend hyprland functionality usi
 - [ashell](https://github.com/MalpenZibo/ashell) ![rust][rs] (A ready to go Wayland status bar for Hyprland)
 - [ignis](https://github.com/linkfrg/ignis) ![python][py] (GTK4-based widget framework for bars and other widgets)
 - [hypr-dock](https://github.com/lotos-linux/hypr-dock) ![go][go] (Interactive dock-panel for Hyprland)
+- [aifuel](https://github.com/robertogogoni/aifuel) ![go][go] (Real-time AI provider usage monitor for waybar with Chrome extension, bubbletea TUI, and Catppuccin theme)
 
 ### Notifications
 


### PR DESCRIPTION
Adding [aifuel](https://github.com/robertogogoni/aifuel) to the Status Bar/Shell section.

aifuel is a Go CLI that monitors AI provider usage (Claude, Codex, Gemini, Copilot) and renders it as a color-coded fuel gauge in waybar. Features include a Chrome extension with popup and toolbar badge, bubbletea TUI dashboard, Admin API cost reports, and Catppuccin Mocha theming.

Install: `curl -fsSL https://raw.githubusercontent.com/robertogogoni/aifuel/master/install.sh | bash`