### PR TITLE
Add dotfiles-mcp — MCP server with 60+ Hyprland IPC tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ These technically aren't hyprland plugins, but extend hyprland functionality usi
         - [shift_monitors](https://github.com/hyprland-community/pyprland/wiki/shift_monitors) (Swaps monitors' workspaces)
         - [workspaces_follow_focus](https://github.com/hyprland-community/pyprland/wiki/workspaces_follow_focus) (Allows using any workspace on any monitor in a natural way)
 - [hdrop_python](https://github.com/ZeroMapleQvQ/hdrop_python) ![python][py] (A python re-implementation of [contrib/hdrop](https://github.com/hyprwm/contrib/tree/main/hdrop))
+- [dotfiles-mcp](https://github.com/hairglasses-studio/dotfiles-mcp) ![go][go] (MCP server with 60+ Hyprland IPC tools: window/workspace/monitor management, screenshots, input simulation, config tuning, shader control. Also includes 350+ workstation tools. Built on [mcpkit](https://github.com/hairglasses-studio/mcpkit))
 
 ## Tools
 


### PR DESCRIPTION
## What

[dotfiles-mcp](https://github.com/hairglasses-studio/dotfiles-mcp) is a Go MCP (Model Context Protocol) server that gives AI agents direct control over a Hyprland desktop via IPC:

- **60+ Hyprland tools**: list/focus/move/resize windows, switch workspaces, configure monitors, take screenshots, inject keystrokes, reload config, set keywords live, layout save/restore
- **23 kitty terminal tools**: tab/window management, theme cycling, scrollback capture
- **13 shader tools**: manage 139 DarkWindow GLSL shaders with playlist rotation
- **5 keybind management tools**: inventory, search, conflict detection, free slot discovery

Install: `go install github.com/hairglasses-studio/dotfiles-mcp@latest`

Built on [mcpkit](https://github.com/hairglasses-studio/mcpkit) (Go MCP toolkit). MIT licensed.

## Category

Added to **IPC plugins** section — it extends Hyprland functionality using only IPC, matching the section's description.

## Notes

This is the first MCP server targeting the Hyprland IPC surface. The awesome-hyprland list currently has no AI/MCP/agent entries.