### PR TITLE
Add awob to Tools/Notifications/OSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ These technically aren't hyprland plugins, but extend hyprland functionality usi
 - [SwayOSD](https://github.com/ErikReider/SwayOSD) ![rust][rs] (GNOME like OSD written in gtk)
 - [Avizo](https://github.com/misterdanb/avizo) ![vala][va] (macOS like OSD written in gtk, also comes with nice scripts)
 - [Wob](https://github.com/francma/wob) ![c][c] (dead simple OSD inspired by xob)
+- [awob](https://github.com/jmylchreest/awob) ![rust][rs] (Wayland OSD bar — drop-in replacement for wob with KDL-based theming, typed IPC, and a listener ecosystem)
 - [syshud](https://github.com/System64fumo/syshud) ![c++][cpp] (Simple heads up display)
 - [nwg-hud](https://github.com/nwg-piotr/nwg-shell-config#nwg-hud) ![python][py] (Simple script that allows for creation of custom OSDs/HUDs)
 


### PR DESCRIPTION
Adding [awob](https://github.com/jmylchreest/awob) to the OSD subsection.

awob is *Another Wayland Overlay Bar* — a Wayland-only OSD daemon written in Rust. It's positioned as a drop-in replacement for [wob](https://github.com/francma/wob) (already listed) for users who want a richer theming model and structured IPC, while keeping the same minimum-viable footprint:

- KDL-based theme files (palette + named styles + element tree + animation phases all in one self-contained file).
- Typed IPC: \`(source, event, value, max, style?, icon?, app?)\` over a Unix socket. wob's positional FIFO format still works via a shim listener.
- One binary per process — daemon, CLI, and a listener per event source (PipeWire volume, sysfs battery + udev, sysfs backlight, keyboard backlight, wob FIFO bridge). The daemon's supervisor auto-discovers them on \`PATH\`.

Renderer is \`wlr-layer-shell-v1\` + \`tiny-skia\` + \`cosmic-text\` + \`resvg\`. No GTK, no Qt.

AUR packages live as \`awob-bin\`, per-listener \`awob-listener-*-bin\`, the meta-package \`awob-listeners-all\`, and \`awob-git\`.

Happy to adjust wording or move the line if there's a better spot — left it directly under the existing Wob entry since they're closely related.