### PR TITLE
Add histui to Tools/Notifications/Notification Daemons

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ These technically aren't hyprland plugins, but extend hyprland functionality usi
 - [SwayNotificationCenter](https://github.com/ErikReider/SwayNotificationCenter) ![vala][va] (GNOME like notification daemon, with GUI and all)
 - [fnott](https://codeberg.org/dnkl/fnott) ![c][c] (Featureful and configurable notification daemon)
 - [hyprnotify](https://github.com/codelif/hyprnotify) ![go][go] (Notification daemon with 'hyprctl notify' as backend)
+- [histui](https://github.com/jmylchreest/histui) ![go][go] (Highly themeable GTK4 notification daemon for Wayland with persistent history, TUI browser, and CLI tools)
 
 #### OSD
 


### PR DESCRIPTION
Adding [histui](https://github.com/jmylchreest/histui) to the Notification Daemons subsection.

histui is a highly themeable GTK4 notification daemon for Wayland (Go), with:

- Persistent notification history (SQLite-backed), so you can scroll back through what you've missed.
- A TUI browser (\`histui browse\`) for searching / filtering / dismissing past notifications without leaving the terminal.
- CLI tools (\`histui list\`, \`histui clear\`, etc.) for shell scripting.
- GTK4 rendering with theming via CSS — looks at home alongside other GTK Wayland tools.

Implements \`org.freedesktop.Notifications\` so it Just Works as a drop-in for mako / dunst / fnott / SwayNotificationCenter on Hyprland.

Appended at the end of the existing Notification Daemons list — happy to adjust ordering or wording.