### PR TITLE
Add Theming subsection (with tinct)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ These technically aren't hyprland plugins, but extend hyprland functionality usi
 - ~~[hyprwall](https://github.com/nnyyxxxx/hyprwall)~~ ![rust][rs](GUI for setting wallpapers with hyprpaper, swww, swaybg, wallutils, and feh)
 > Deleted, fork of hyprwall available at <https://github.com/MarkusVolk/hyprwall>
 
+### Theming
+
+- [tinct](https://github.com/jmylchreest/tinct) ![go][go] (Plugin-based theme/templating tool inspired by Pywal and Matugen, with multiple input mechanisms)
+
 ### Display
 
 - [iio-hyprland](https://github.com/JeanSchoeller/iio-hyprland) ![c][c] (Listen iio-sensor-proxy and auto change Hyprland output orientation)


### PR DESCRIPTION
Proposing a new \`### Theming\` subsection under Tools, with [tinct](https://github.com/jmylchreest/tinct) as the first entry.

There's currently no home in the list for Pywal/Matugen-style colour-scheme generators that don't *also* set wallpapers. tinct is one such tool: a plugin-based templating engine that extracts a colour palette from inputs and renders templates for any application that consumes them (terminals, editors, status bars, OSDs, GTK / Qt themes, etc.). Inputs are pluggable — wallpapers, hex codes, image URLs, the time of day — so the same template chain works regardless of how the palette is sourced.

Inserted between \`### Wallpaper\` and \`### Display\` since theming is the most natural neighbour of wallpaper tools structurally.

If maintainers prefer not to add a new subsection, happy to close this PR or move tinct anywhere it fits better — wanted to flag the gap rather than try to wedge a templating tool into Wallpaper or Misc.