### PR TITLE
Add wflow to Tools/Input

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ These technically aren't hyprland plugins, but extend hyprland functionality usi
 - [hyprland-per-window-layout](https://github.com/coffebar/hyprland-per-window-layout) ![rust][rs] (Per window keyboard layout, zero-configuration, just works out of the box)
 - [hyprland-per-window-layout](https://github.com/MahouShoujoMivutilde/hyprland-per-window-layout) ![shell][sh] (Script to maintain per window keyboard layout) (language)
 - [Keymapper](https://github.com/houmain/keymapper) ![c++][cpp] (A cross-platform context-aware key remapper)
+- [wflow](https://github.com/cushycush/wflow) ![rust][rs] (Bind keyboard chords to multi-step workflows, plain-text KDL files; uses the GlobalShortcuts portal where available and Hyprland IPC otherwise)
 
 #### On-screen Keyboards
 


### PR DESCRIPTION
wflow is a desktop automation engine that just hit 1.0. Hyprland is
a first-class target: when the GlobalShortcuts portal is not
available, the daemon writes bind directives via Hyprland's IPC
socket pointing back at \`wflow run <id> --yes\`. Hot-reloads on
workflow file changes via inotify.

Workflows are plain-text KDL files. Bind a chord, fire a multi-step
recipe (shell, key, type, focus, wait, conditionals, repeat). The
catalog at wflows.io has imports working end-to-end via the
\`wflow://\` URL scheme.

Repo: github.com/cushycush/wflow
Catalog: wflows.io
License: MIT/Apache-2.0 dual

Slotted under Tools/Input alphabetically after Keymapper.