### PR TITLE
Add hyprgamma: per-monitor brightness, contrast, and gamma control plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Awesome list for Hyprland, that includes useful tools and libraries that either 
 - [Hyprmodoro](https://github.com/0xFMD/hyprmodoro) ![c++][cpp] (A Pomodoro timer that shows progress in your window borders)   
 - [hyprtoplr](https://github.com/SsubezZ/hyprtoplr) ![c++][cpp] (Hyprland plugin for temporarily toggling top layer plugins above fullscreen windows)
 - [Hyprtasking](https://github.com/raybbian/hyprtasking) ![c++][cpp] (Powerful workspace management plugin, packed with features)
+- [hyprgamma](https://github.com/surprizeattackxx-dotcom/hypr-gamma) ![c++][cpp] (Per-monitor brightness, contrast, and gamma control with GTK4 GUI)
 
 
 


### PR DESCRIPTION
Adds [hyprgamma](https://github.com/surprizeattackxx-dotcom/hypr-gamma) to the community plugins list.

A Hyprland plugin for per-monitor brightness, contrast, and gamma control, with a companion GTK4 GUI for live adjustments.