### PR TITLE
Add hyprcaffeine: idle inhibition utility for Hyprland

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ These technically aren't hyprland plugins, but extend hyprland functionality usi
 
 - [hypridle](https://github.com/hyprwm/hypridle) ![c++][cpp] (Hyprland's idle daemon)
 - [swayidle](https://github.com/swaywm/swayidle) ![c][c] (Idle daemon used by default in sway, also only one I could find for wlroots)
+- [hyprcaffeine](https://github.com/hbuddenberg/hyprcaffeine) ![bash][sh] (Idle inhibition utility with Waybar integration, systemd service, and Walker menu frontend)
 
 #### Lockers
 


### PR DESCRIPTION
## Add HyprCaffeine to Idle Daemons

**HyprCaffeine** is an idle inhibition utility for Hyprland that complements `hypridle` by providing user-friendly control over caffeine/idle states:

- **Waybar integration** with color-coded status icons and click actions
- **Walker/wofi/gum menu** frontend for duration selection (15m, 30m, 1h, 2h, custom, infinite)
- **Monitor & Lid inhibition** via systemd-logind (polkit rule)
- **Systemd user service** for state persistence across sessions
- **Timer-based** or **infinite** idle inhibition
- Available on **AUR**: `yay -S hyprcaffeine`

**Repo:** https://github.com/hbuddenberg/hyprcaffeine
**License:** MIT
