### PR TITLE
Strikethrough deprecated official plugins: hyprexpo and hyprscrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ Awesome list for Hyprland, that includes useful tools and libraries that either 
 - [border++](https://github.com/hyprwm/hyprland-plugins/tree/main/borders-plus-plus) ![c++][cpp] (Adds one or two additional borders to windows)
 - [cs:go vulkan fix](https://github.com/hyprwm/hyprland-plugins/tree/main/csgo-vulkan-fix) ![c++][cpp] (Fixes custom resolutions on CS:GO with -vulkan)
 - [hyprbars](https://github.com/hyprwm/hyprland-plugins/tree/main/hyprbars) ![c++][cpp] (Adds title bars to windows)
-- [hyprexpo](https://github.com/hyprwm/hyprland-plugins/tree/main/hyprexpo) ![c++][cpp] (Adds an expo-like workspace overview)
 - [hyprfocus](https://github.com/hyprwm/hyprland-plugins/tree/main/hyprfocus) ![c++][cpp](Flashfocus for hyprland)
-- [hyprscrolling](https://github.com/hyprwm/hyprland-plugins/tree/main/hyprscrolling)![c++][cpp](Adds a scrolling layout to hyprland)
 - [hyprtrails](https://github.com/hyprwm/hyprland-plugins/tree/main/hyprtrails) ![c++][cpp] (Adds trails behind windows)
 - [hyprwinwrap](https://github.com/hyprwm/hyprland-plugins/tree/main/hyprwinwrap) ![c++][cpp] (Allows you to put any app as a wallpaper)
 - [xtra-dispatchers](https://github.com/hyprwm/hyprland-plugins/tree/main/xtra-dispatchers) ![c++][cpp](Adds some new dispatchers)
+- ~[hyprexpo](https://github.com/hyprwm/hyprland-plugins/tree/main/hyprexpo) ![c++][cpp] (Adds an expo-like workspace overview)~
+- ~[hyprscrolling](https://github.com/hyprwm/hyprland-plugins/tree/main/hyprscrolling)![c++][cpp](Adds a scrolling layout to hyprland)~
 
 
 ### IPC plugins


### PR DESCRIPTION
These two plugins were abandoned by vaxerski [1](https://github.com/hyprwm/hyprland-plugins/pull/507#issuecomment-4433386463) [2](https://github.com/hyprwm/hyprland-plugins/pull/663)

LMK if you were prefer them to be completely removed from the list and I'll update it. Due to the context, I figured a strikethrough made sense for a while.

## Note: 

There are **two active forks** for HyprExpo, could not locate any forks for HyprScrolling

https://github.com/sandwichfarm/hyprexpo (~8 months)
https://github.com/colonelpanic8/hyprexpo (~1 week)

Not sure how to properly organize these in your hierarchy.