### PR TITLE
feat: add hyprselect to Workspace tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ These technically aren't hyprland plugins, but extend hyprland functionality usi
 - [Hyprfreeze](https://github.com/Zerodya/hyprfreeze) ![shell][sh] (Utility to suspend a game process and other programs)
 - [hyprkool](https://github.com/thrombe/hyprkool) ![rust][rs] (Plugin that adds KDE Plasma activities and grid layouts and cusor edge workspace navigation)
 - [hyprswitch](https://github.com/H3rmt/hyprswitch) ![rust][rs] (A CLI/GUI that allows switching between windows in Hyprland)
+- [hyprselect](https://github.com/K-REBO/hyprselect) ![rust][rs] (Visually focus windows by label using keyboard hints, fork of wmfocus with active Hyprland/Wayland support)
 - [hypr-ws-switcher](https://github.com/jasper-at-windswept/hypr-ws-switcher) ![shell][sh] (A script to switch workspaces based on the active screen, like awesomewm)
 - ~~[hypract](https://github.com/hyprland-community/hypract) ![rust][rs] (Adds KDE plasma like activities to Hyprland )~~ (Deprecated, use hyprkool instead)
 - [hyprnavi](https://github.com/ckaznable/hyprnavi) ![rust][rs] (Simple horizontal navigation feature for hyprland)


### PR DESCRIPTION
## Summary

- Adds [hyprselect](https://github.com/K-REBO/hyprselect) to the Workspace section
- hyprselect is a fork of [wmfocus](https://github.com/svenstaro/wmfocus) with active Hyprland/Wayland support
- Allows rapidly focusing any window by pressing a keyboard hint label — no mouse or directional navigation needed