### PR TITLE
feat: waylandar update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ These technically aren't hyprland plugins, but extend hyprland functionality usi
 - [hypr-dock](https://github.com/lotos-linux/hypr-dock) ![go][go] (Interactive dock-panel for Hyprland)
 - [wayle](https://github.com/wayle-rs/wayle) ![rust][rs] (A Wayland desktop shell with the bar, notifications, OSD, wallpaper, and device controls built in.)
 - [Tide-island](https://github.com/enhaoswen/Tide-island) ![c++][cpp] (Lightweight, flexible interactive island for Hyprland)
+- [waylandar](https://github.com/samjoshuadud/waylandar) ![python][py] (A standalone Wayland calendar widget and dashboard built with Quickshell, featuring native sync for Google Calendar, CalDAV, ICS feeds, and dynamic Matugen theming)
 
 ### Notifications
 


### PR DESCRIPTION
- Waylandar is a calendar widget built with Quickshell/QML. 
- Supports Google Calendar, Nextcloud CalDAV, and any ICS URL. 
- Has a PKGBUILD and NixOS flake. 