### PR TITLE
feat: add arch-agent-skill to config managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Awesome list for Hyprland, that includes useful tools and libraries that either 
 - [hyprconf-gen](https://github.com/ufuayk/hyprconf-gen) ![javascript][js] (Lightweight Website for managing Hyprland configs)
 - [Uniconf](https://github.com/dsksnkz/uniconf) ![javascript][js] (Manages hyprland configs in a website)
 - [hyprSettings](https://github.com/acropolis914/hyprsettings) ![typescript][ts] (Hyprland.conf UI manager settings)
+- [arch-agent-skill](https://github.com/IPauloGermano/arch-agent-skill) (Modular AI Agent Skill for Hyprland and Arch Linux desktop configuration and automation)
 
 
 ## Plugins


### PR DESCRIPTION
### 📌 Title (Título do PR):
  
    Add arch-agent-skill to Config managers
  ──────
  ### 📝 Description (Descrição do PR):
  
    ### Summary
    Adds [arch-agent-skill](https://github.com/IPauloGermano/arch-agent-skill) to the  
  **Config managers** section.
  
    ### About the project
    **arch-agent-skill** is a modular, production-ready AI Agent Skill that enables AI 
  coding assistants (Gemini, Claude, Antigravity, Open Agent Skills) to safely         
  configure, automate, and theme Hyprland (native syntax, window rules v2, Waybar,     
  monitors, and system utilities) on Arch Linux.