### PR TITLE
feat: add shotdock to screenshotting tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ These technically aren't hyprland plugins, but extend hyprland functionality usi
 - [Hyprshot](https://github.com/Gustash/Hyprshot) ![shell][sh] (Another grimshot-like tool to make things easier)
 - [satty](https://github.com/gabm/satty) ![rust][rs] (A screenshot annotation tool inspired by Swappy and Flameshot)
 - [swappy](https://github.com/jtheoof/swappy) ![c][c] (A Wayland native snapshot editing tool, inspired by Snappy on macOS)
+- [shotdock](https://github.com/sirrryasir/shotdock) ![rust][rs] (Automated window framing, soft drop shadows, and studio screen capture/recording tool)
 
 #### Raw Tools
 


### PR DESCRIPTION
Adds shotdock to the Screenshotting (All in one Tools) section.

shotdock is a Rust/GTK4 LayerShell screenshot, recording, and automated window framing utility for Wayland compositors (Hyprland, Sway, Niri).
